### PR TITLE
Cleanup / housekeeping

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -483,9 +483,9 @@
       }
     },
     "@types/json-schema": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.3.tgz",
-      "integrity": "sha512-Il2DtDVRGDcqjDtE+rF8iqg1CArehSK84HZJCT7AMITlyXRBpuPhqGLDQMowraqqu1coEaimg4ZOqggt6L6L+A==",
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.4.tgz",
+      "integrity": "sha512-8+KAKzEvSUdeo+kmqnKrqgeE+LcA0tjYWFY7RPProVYwnqDjukzO+3b6dLD56rYX5TdWejnEOLJYOIeh4CXKuA==",
       "dev": true
     },
     "@types/minimatch": {
@@ -495,9 +495,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "12.12.21",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.21.tgz",
-      "integrity": "sha512-8sRGhbpU+ck1n0PGAUgVrWrWdjSW2aqNeyC15W88GRsMpSwzv6RJGlLhE7s2RhVSOdyDmxbqlWSeThq4/7xqlA==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.1.0.tgz",
+      "integrity": "sha512-zwrxviZS08kRX40nqBrmERElF2vpw4IUTd5khkhBTfFH8AOaeoLVx48EC4+ZzS2/Iga7NevncqnsUSYjM4OWYA==",
       "dev": true
     },
     "@types/rimraf": {
@@ -532,12 +532,12 @@
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.12.0.tgz",
-      "integrity": "sha512-1t4r9rpLuEwl3hgt90jY18wJHSyb0E3orVL3DaqwmpiSDHmHiSspVsvsFF78BJ/3NNG3qmeso836jpuBWYziAA==",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.13.0.tgz",
+      "integrity": "sha512-QoiANo0MMGNa8ej/yX3BrW5dZj5d8HYcKiM2fyYUlezECqn8Xc7T/e4EUdiGinn8jhBrn+9X47E9TWaaup3u1g==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/experimental-utils": "2.12.0",
+        "@typescript-eslint/experimental-utils": "2.13.0",
         "eslint-utils": "^1.4.3",
         "functional-red-black-tree": "^1.0.1",
         "regexpp": "^3.0.0",
@@ -545,32 +545,32 @@
       }
     },
     "@typescript-eslint/experimental-utils": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.12.0.tgz",
-      "integrity": "sha512-jv4gYpw5N5BrWF3ntROvCuLe1IjRenLy5+U57J24NbPGwZFAjhnM45qpq0nDH1y/AZMb3Br25YiNVwyPbz6RkA==",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.13.0.tgz",
+      "integrity": "sha512-+Hss3clwa6aNiC8ZjA45wEm4FutDV5HsVXPl/rDug1THq6gEtOYRGLqS3JlTk7mSnL5TbJz0LpEbzbPnKvY6sw==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.3",
-        "@typescript-eslint/typescript-estree": "2.12.0",
+        "@typescript-eslint/typescript-estree": "2.13.0",
         "eslint-scope": "^5.0.0"
       }
     },
     "@typescript-eslint/parser": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.12.0.tgz",
-      "integrity": "sha512-lPdkwpdzxEfjI8TyTzZqPatkrswLSVu4bqUgnB03fHSOwpC7KSerPgJRgIAf11UGNf7HKjJV6oaPZI4AghLU6g==",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.13.0.tgz",
+      "integrity": "sha512-vbDeLr5QRJ1K7x5iRK8J9wuGwR9OVyd1zDAY9XFAQvAosHVjSVbDgkm328ayE6hx2QWVGhwvGaEhedcqAbfQcA==",
       "dev": true,
       "requires": {
         "@types/eslint-visitor-keys": "^1.0.0",
-        "@typescript-eslint/experimental-utils": "2.12.0",
-        "@typescript-eslint/typescript-estree": "2.12.0",
+        "@typescript-eslint/experimental-utils": "2.13.0",
+        "@typescript-eslint/typescript-estree": "2.13.0",
         "eslint-visitor-keys": "^1.1.0"
       }
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.12.0.tgz",
-      "integrity": "sha512-rGehVfjHEn8Frh9UW02ZZIfJs6SIIxIu/K1bbci8rFfDE/1lQ8krIJy5OXOV3DVnNdDPtoiPOdEANkLMrwXbiQ==",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.13.0.tgz",
+      "integrity": "sha512-t21Mg5cc8T3ADEUGwDisHLIubgXKjuNRbkpzDMLb7/JMmgCe/gHM9FaaujokLey+gwTuLF5ndSQ7/EfQqrQx4g==",
       "dev": true,
       "requires": {
         "debug": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "typescript"
   ],
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=10.12.0"
   },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -46,12 +46,13 @@
     "email": "cafebab3@gmail.com",
     "url": "https://danieldietrich.dev"
   },
+  "funding": "https://github.com/sponsors/danieldietrich",
   "license": "MIT",
   "devDependencies": {
     "@types/jest": "^24.0.24",
-    "@types/node": "^12.12.21",
-    "@typescript-eslint/eslint-plugin": "^2.12.0",
-    "@typescript-eslint/parser": "^2.12.0",
+    "@types/node": "^13.1.0",
+    "@typescript-eslint/eslint-plugin": "^2.13.0",
+    "@typescript-eslint/parser": "^2.13.0",
     "@types/rimraf": "^2.0.3",
     "codecov": "^3.6.1",
     "eslint": "^6.8.0",

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -13,7 +13,6 @@ const mkdir = promisify(fs.mkdir);
 const rmdir = promisify(rimraf);
 const readlink = promisify(fs.readlink);
 const symlink = promisify(fs.symlink);
-const unlink = promisify(fs.unlink);
 const utimes = promisify(fs.utimes);
 const writeFile = promisify(fs.writeFile);
 
@@ -89,7 +88,6 @@ describe('Options.dereference', () => {
 
     test('Should fail when trying to dereference broken links', async () => {
         const tmp = await tempDir();
-        await unlink(`${tmp}/src/d1/l2`);
         await expect(copy(`${tmp}/src`, `${tmp}/dst`, { dereference: true })).rejects.toThrow(Error("ENOENT: no such file or directory, copyfile '__tmp/src/d1/d3/l1' -> '__tmp/dst/d1/d3/l1'"));
     });
 


### PR DESCRIPTION
For recursive mkdir, at least node 10.12.0 is needed. If I use node 10.11.0, 3 tests fail.

When using node 10.11.0, a 4th test failed sporadically with a race condition. After removing an unnecessary `fs.unlink` call from a test and upgrading node to the latest stable, the race condition did not occur anymore. The travis-ci tests also never fail with a race condition, so I consider the re-opened issue #14 to be solved.